### PR TITLE
symfony_timestampable behavior doesn't work properly with propel soft_delete behavior

### DIFF
--- a/lib/behavior/SfPropelBehaviorTimestampable.php
+++ b/lib/behavior/SfPropelBehaviorTimestampable.php
@@ -51,13 +51,23 @@ EOF;
 
     if ($column = $this->getParameter('update_column'))
     {
-      return <<<EOF
-if (\$this->isModified() && !\$this->isColumnModified({$this->getTable()->getColumn($column)->getConstantName()}))
+      if($this->getTable()->hasBehavior('soft_delete'))
+      {
+        $deletedColumn = $this->getTable()->getBehavior('soft_delete')->getParameter('deleted_column');
+        $string = "if (\$this->isModified() && !\$this->isColumnModified({$this->getTable()->getColumn($column)->getConstantName()}) && !\$this->isColumnModified({$this->getTable()->getColumn($deletedColumn)->getConstantName()}))
 {
   \$this->set{$this->getTable()->getColumn($column)->getPhpName()}(time());
-}
+}";
+      }
+      else
+      {
+        $string = "if (\$this->isModified() && !\$this->isColumnModified({$this->getTable()->getColumn($column)->getConstantName()}))
+{
+  \$this->set{$this->getTable()->getColumn($column)->getPhpName()}(time());
+}";
+      }
 
-EOF;
+      return $string;
     }
   }
 }


### PR DESCRIPTION
This pull request adds a buildtime check for the propel soft_delete behavior and modifies the runtime preSave() hooks to not set updated_at during a soft delete.
