### PR TITLE
Fixed route class names *Propel15* => *PropelORM*

### DIFF
--- a/lib/routing/sfPropelORMRoute.class.php
+++ b/lib/routing/sfPropelORMRoute.class.php
@@ -18,7 +18,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfObjectRoute.class.php 20784 2009-08-04 20:53:57Z Kris.Wallsmith $
  */
-class sfPropel15Route extends sfRequestRoute
+class sfPropelORMRoute extends sfRequestRoute
 {
   protected
     $object  = false,
@@ -288,6 +288,6 @@ class sfPropel15Route extends sfRequestRoute
     {
       return call_user_func_array(array($this, 'getObject'), $arguments);
     }
-    throw new Exception(sprintf('Call to undefined method sfPropel15Route::%s.', $name));
+    throw new Exception(sprintf('Call to undefined method sfPropelORMRoute::%s.', $name));
   }
 }

--- a/lib/routing/sfPropelORMRouteCollection.class.php
+++ b/lib/routing/sfPropelORMRouteCollection.class.php
@@ -16,10 +16,10 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfPropelRouteCollection.class.php 12755 2008-11-08 09:48:03Z fabien $
  */
-class sfPropel15RouteCollection extends sfObjectRouteCollection
+class sfPropelORMRouteCollection extends sfObjectRouteCollection
 {
   protected
-    $routeClass = 'sfPropel15Route';
+    $routeClass = 'sfPropelORMRoute';
 
   /**
    * Constructor.

--- a/lib/task/sfPropelGenerateAdminTask.class.php
+++ b/lib/task/sfPropelGenerateAdminTask.class.php
@@ -64,7 +64,7 @@ For the filters and batch actions to work properly, you need to add
 the [with_wildcard_routes|COMMENT] option to the route:
 
   article:
-    class: sfPropel15RouteCollection
+    class: sfPropelORMRouteCollection
     options:
       model:                Article
       with_wildcard_routes: true
@@ -120,7 +120,7 @@ EOF;
       $module = $options['module'] ? $options['module'] : $name;
       $content = sprintf(<<<EOF
 %s:
-  class: sfPropel15RouteCollection
+  class: sfPropelORMRouteCollection
   options:
     model:                %s
     module:               %s
@@ -146,7 +146,7 @@ EOF
   {
     $routeOptions = $arguments['route']->getOptions();
 
-    if (!$arguments['route'] instanceof sfPropel15RouteCollection)
+    if (!$arguments['route'] instanceof sfPropelORMRouteCollection)
     {
       throw new sfCommandException(sprintf('The route "%s" is not a Propel collection route.', $arguments['route_name']));
     }
@@ -197,7 +197,7 @@ EOF
    */
   protected function checkRoute($route, $model, $module)
   {
-    if ($route instanceof sfPropel15RouteCollection)
+    if ($route instanceof sfPropelORMRouteCollection)
     {
       $options = $route->getOptions();
       return $model == $options['model'] && $module == $options['module'];


### PR DESCRIPTION
Hi there

I could be wrong but this looks like a simple typo.
I've discovered this few minutes ago when my admin-generator based application stopped working.
