### PR TITLE
Reviewed connection parameter in Form/Filter Generator and PropelData. fixes #84, #85

### DIFF
--- a/lib/addon/sfPropelData.class.php
+++ b/lib/addon/sfPropelData.class.php
@@ -60,7 +60,7 @@ class sfPropelData extends sfData
     $files = $this->getFiles($directoryOrFile);
 
     // load map classes
-    $this->loadMapBuilders();
+    $this->loadMapBuilders($connectionName);
     $this->dbMap = Propel::getDatabaseMap($connectionName);
 
     // wrap all database operations in a single transaction
@@ -304,14 +304,14 @@ class sfPropelData extends sfData
    *
    * @throws sfException If the class cannot be found
    */
-  protected function loadMapBuilders()
+  protected function loadMapBuilders($connectionName)
   {
     $dbMap = Propel::getDatabaseMap();
     $files = sfFinder::type('file')->name('*TableMap.php')->in(sfProjectConfiguration::getActive()->getModelDirs());
     foreach ($files as $file)
     {
       $omClass = basename($file, 'TableMap.php');
-      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject'))
+      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject') && constant($omClass.'Peer::DATABASE_NAME') == $connectionName)
       {
         $tableMapClass = basename($file, '.php');
         $dbMap->addTableFromMapClass($tableMapClass);
@@ -360,7 +360,7 @@ class sfPropelData extends sfData
    */
   public function getData($tables = 'all', $connectionName = 'propel')
   {
-    $this->loadMapBuilders();
+    $this->loadMapBuilders($connectionName);
     $this->con = Propel::getConnection($connectionName);
     $this->dbMap = Propel::getDatabaseMap($connectionName);
 

--- a/lib/generator/sfPropelFormFilterGenerator.class.php
+++ b/lib/generator/sfPropelFormFilterGenerator.class.php
@@ -60,8 +60,6 @@ class sfPropelFormFilterGenerator extends sfPropelFormGenerator
 
     $this->loadBuilders();
 
-    $this->dbMap = Propel::getDatabaseMap($this->params['connection']);
-
     // create the project base class for all forms
     $file = sfConfig::get('sf_lib_dir').'/filter/BaseFormFilterPropel.class.php';
     if (!file_exists($file))

--- a/lib/generator/sfPropelFormGenerator.class.php
+++ b/lib/generator/sfPropelFormGenerator.class.php
@@ -61,8 +61,6 @@ class sfPropelFormGenerator extends sfGenerator
       $this->params['form_dir_name'] = 'form';
     }
 
-    $this->dbMap = Propel::getDatabaseMap($this->params['connection']);
-
     $this->loadBuilders();
 
     // create the project base class for all forms
@@ -536,7 +534,7 @@ class sfPropelFormGenerator extends sfGenerator
     foreach ($classes as $class)
     {
       $omClass = basename($class, 'TableMap.php');
-      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject'))
+      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject') && constant($omClass.'Peer::DATABASE_NAME') == $this->params['connection'])
       {
         $tableMapClass = basename($class, '.php');
         $this->dbMap->addTableFromMapClass($tableMapClass);


### PR DESCRIPTION
Hi there,

Fabien Potencier and I fixed a bug in sfPropelPlugin, and this patch should also be merged to sfPropelORMPlug (the diff can be found here : http://bit.ly/rguFhj ).

There was a mistake in some tasks : all classes under all connections were loaded to hydrate the DatabaseMap instead of those of the connection only. This patch fixes the bugs #85 and #84.

But we may have to add a feature: by default, use a keyword (like "all") as connection parameter in the tasks and run the generation subtask for each connection in the configuration. 
What do you think about this ?
