### PR TITLE
class sfPropelORMRoute must extend sfObjectRoute...

### DIFF
--- a/lib/routing/sfPropelORMRoute.class.php
+++ b/lib/routing/sfPropelORMRoute.class.php
@@ -18,7 +18,7 @@
  * @author     Fabien Potencier <fabien.potencier@symfony-project.com>
  * @version    SVN: $Id: sfObjectRoute.class.php 20784 2009-08-04 20:53:57Z Kris.Wallsmith $
  */
-class sfPropelORMRoute extends sfRequestRoute
+class sfPropelORMRoute extends sfObjectRoute
 {
   protected
     $object  = false,


### PR DESCRIPTION
...in order to allow some nice routing tricks, like generating admin modules on tables with composite PKs.
Fixes exactly this issue: http://trac.symfony-project.org/ticket/9207
