### PR TITLE
Problems with Enums Values and White Spaces

### DIFF
--- a/lib/generator/sfPropelFormGenerator.class.php
+++ b/lib/generator/sfPropelFormGenerator.class.php
@@ -284,7 +284,7 @@ class sfPropelFormGenerator extends sfGenerator
       $valueSet = $column->getValueSet();
       $choices = array_merge(array(''=>''), array_combine($valueSet, $valueSet));
 
-      $options[] = sprintf("'choices' => %s", preg_replace('/[\n\r]+/', '', var_export($choices, true)));
+      $options[] = sprintf("'choices' => %s", preg_replace('/[\n\r]+/', '', var_export($choices, true))); 
     }
 
     return count($options) ? sprintf('array(%s)', implode(', ', $options)) : '';
@@ -402,7 +402,7 @@ class sfPropelFormGenerator extends sfGenerator
          break;
        case PropelColumnTypes::ENUM:
          $valueSet = $column->getValueSet();
-         $options[] = sprintf("'choices' => %s", preg_replace('/[\n\r]+/', '', var_export($valueSet, true)));
+         $options[] = sprintf("'choices' => %s", preg_replace('/[\n\r]+/', '', var_export($valueSet, true)));  
          break;
       }
     }

--- a/test/functional/fixtures/apps/frontend/modules/enum/actions/actions.class.php
+++ b/test/functional/fixtures/apps/frontend/modules/enum/actions/actions.class.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * choice actions.
+ *
+ * @package    ##PROJECT_NAME##
+ * @subpackage choice
+ * @author     Your name here
+ * @version    SVN: $Id: actions.class.php 16987 2009-04-04 14:16:46Z fabien $
+ */
+class enumActions extends sfActions
+{
+  public function executeEnum($request)
+  {
+    $this->form = new EnumSampleForm();
+    $this->form->setDefault('enum_values','three space');
+  }
+}

--- a/test/functional/fixtures/apps/frontend/modules/enum/templates/enumSuccess.php
+++ b/test/functional/fixtures/apps/frontend/modules/enum/templates/enumSuccess.php
@@ -1,0 +1,10 @@
+<form action="<?php echo url_for('enum/enum') ?>" method="post">
+  <table>
+    <?php echo $form['enum_values']->render(); ?>
+    <tr>
+      <td colspan="2">
+        <input type="submit" value="submit" />
+      </td>
+    </tr>
+  </table>
+</form>

--- a/test/functional/fixtures/config/schema.xml
+++ b/test/functional/fixtures/config/schema.xml
@@ -144,5 +144,9 @@
       <reference local="article_id" foreign="id" onDelete="setnull" />
     </foreign-key>
   </table>
-
+  
+  <table name="enum_sample">
+    <column name="id" type="integer" required="true" primaryKey="true" autoincrement="true" />
+    <column name="enum_values" type="enum" valueSet="one, two, three space" />    
+  </table>
 </database>

--- a/test/functional/formTest.php
+++ b/test/functional/formTest.php
@@ -278,3 +278,16 @@ $b->
     isError('author_article_list', 'invalid')->
   end()
 ;
+
+//Checks if the generator can create a choices widget based on a enum values with spaces
+$b->
+  get('/enum/enum')->
+  with('request')->begin()->
+    isParameter('module', 'enum')->
+    isParameter('action', 'enum')->
+  end()->
+  with('response')->begin()->
+    isStatusCode(200)->
+    checkElement('select option[selected="selected"]', 'three space')->
+  end()
+;


### PR DESCRIPTION
Hi Guys, I'm working with enum values using the sfPropelORMPlugin. I
defined this on the schema.

 focus: { type: enum, valueSet: "Working on a Startup, Looking for
Startups" , required: false}

 As you can see, the enumerated values have white spaces.

When I try to generate the form, the generator alters this values on
choices for the widget and the validator, the result is something like
this

''=>'','WorkingonaStartup'=>'WorkingonaStartup','LookingforStartups'=>'LookingforStartups',

Obviously doesn't work because these aren't the valid values of the
enumeration. So I started to digging into the problem and I can see
that in the sfPropelFormGenerator, when the Generator is preparing the
values for choices makes this replace to get all the code on the same
line (with the objetive to get the generated code well formated, I
presume)

```
 $options[] = sprintf("'choices' => %s", preg_replace('/\s+/',
```

'', var_export($choices, true)));

The problem with the replacement is that erases the white spaces on
the Enum value, so I think this is a better expresion to make the
replace without delete the spaces.

```
 $options[] = sprintf("'choices' => %s",
```

preg_replace('/[\n\r]+/', '', var_export($choices, true)));

I'm attaching the patch.

I Hope this will be helpful.
