### PR TITLE
Enable to build forms and filters to work again for all connections #106

### DIFF
--- a/lib/generator/sfPropelFormGenerator.class.php
+++ b/lib/generator/sfPropelFormGenerator.class.php
@@ -534,7 +534,7 @@ class sfPropelFormGenerator extends sfGenerator
     foreach ($classes as $class)
     {
       $omClass = basename($class, 'TableMap.php');
-      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject') && constant($omClass.'Peer::DATABASE_NAME') == $this->params['connection'])
+      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject') && ($this->params['all_connections'] || constant($omClass.'Peer::DATABASE_NAME') == $this->params['connection']))
       {
         $tableMapClass = basename($class, '.php');
         $this->dbMap->addTableFromMapClass($tableMapClass);

--- a/lib/task/sfPropelBuildFiltersTask.class.php
+++ b/lib/task/sfPropelBuildFiltersTask.class.php
@@ -26,11 +26,12 @@ class sfPropelBuildFiltersTask extends sfPropelBaseTask
   protected function configure()
   {
     $this->addOptions(array(
-      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
+      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_OPTIONAL, 'The connection name', false),
       new sfCommandOption('model-dir-name', null, sfCommandOption::PARAMETER_REQUIRED, 'The model dir name', 'model'),
       new sfCommandOption('filter-dir-name', null, sfCommandOption::PARAMETER_REQUIRED, 'The filter form dir name', 'filter'),
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('generator-class', null, sfCommandOption::PARAMETER_REQUIRED, 'The generator class', 'sfPropelFormFilterGenerator'),
+      new sfCommandOption('all-connections', null, sfCommandOption::PARAMETER_REQUIRED, 'To build all connections', true),
     ));
 
     $this->namespace = 'propel';
@@ -45,8 +46,8 @@ The [propel:build-filters|INFO] task creates filter form classes from the schema
 The task read the schema information in [config/*schema.xml|COMMENT] and/or
 [config/*schema.yml|COMMENT] from the project and all installed plugins.
 
-The task use the [propel|COMMENT] connection as defined in [config/databases.yml|COMMENT].
-You can use another connection by using the [--connection|COMMENT] option:
+The task use by default [all-connections|COMMENT] as defined in [config/databases.yml|COMMENT].
+You can use only one connection by using the [--connection|COMMENT] option:
 
   [./symfony propel:build-filters --connection="name"|INFO]
 
@@ -62,6 +63,15 @@ EOF;
    */
   protected function execute($arguments = array(), $options = array())
   {
+    if (false === $options['connection'] && false === $options['all-connections'])
+    {
+        $options['connection'] = 'propel';
+    }
+    elseif (false !== $options['connection'])
+    {
+        $options['all-connections'] = false;
+    }
+
     $this->logSection('propel', 'generating filter form classes');
 
     $generatorManager = new sfGeneratorManager($this->configuration);
@@ -69,6 +79,7 @@ EOF;
       'connection'      => $options['connection'],
       'model_dir_name'  => $options['model-dir-name'],
       'filter_dir_name' => $options['filter-dir-name'],
+      'all_connections' => $options['all-connections'],
     ));
 
     $properties = parse_ini_file(sfConfig::get('sf_config_dir').'/properties.ini', true);

--- a/lib/task/sfPropelBuildFormsTask.class.php
+++ b/lib/task/sfPropelBuildFormsTask.class.php
@@ -26,11 +26,12 @@ class sfPropelBuildFormsTask extends sfPropelBaseTask
   protected function configure()
   {
     $this->addOptions(array(
-      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
+      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_OPTIONAL, 'The connection name', false),
       new sfCommandOption('model-dir-name', null, sfCommandOption::PARAMETER_REQUIRED, 'The model dir name', 'model'),
       new sfCommandOption('form-dir-name', null, sfCommandOption::PARAMETER_REQUIRED, 'The form dir name', 'form'),
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('generator-class', null, sfCommandOption::PARAMETER_REQUIRED, 'The generator class', 'sfPropelFormGenerator'),
+      new sfCommandOption('all-connections', null, sfCommandOption::PARAMETER_REQUIRED, 'To build all connections', true),
     ));
 
     $this->namespace = 'propel';
@@ -45,8 +46,8 @@ The [propel:build-forms|INFO] task creates form classes from the schema:
 The task read the schema information in [config/*schema.xml|COMMENT] and/or
 [config/*schema.yml|COMMENT] from the project and all installed plugins.
 
-The task use the [propel|COMMENT] connection as defined in [config/databases.yml|COMMENT].
-You can use another connection by using the [--connection|COMMENT] option:
+The task use by default [all-connections|COMMENT] as defined in [config/databases.yml|COMMENT].
+You can use only one connection by using the [--connection|COMMENT] option:
 
   [./symfony propel:build-forms --connection="name"|INFO]
 
@@ -62,13 +63,23 @@ EOF;
    */
   protected function execute($arguments = array(), $options = array())
   {
+    if (false === $options['connection'] && false === $options['all-connections'])
+    {
+        $options['connection'] = 'propel';
+    }
+    elseif (false !== $options['connection'])
+    {
+        $options['all-connections'] = false;
+    }
+
     $this->logSection('propel', 'generating form classes');
 
     $generatorManager = new sfGeneratorManager($this->configuration);
     $generatorManager->generate($options['generator-class'], array(
-      'connection'     => $options['connection'],
-      'model_dir_name' => $options['model-dir-name'],
-      'form_dir_name'  => $options['form-dir-name'],
+      'connection'      => $options['connection'],
+      'model_dir_name'  => $options['model-dir-name'],
+      'form_dir_name'   => $options['form-dir-name'],
+      'all_connections' => $options['all-connections'],
     ));
 
     $properties = parse_ini_file(sfConfig::get('sf_config_dir').'/properties.ini', true);


### PR DESCRIPTION
This PR fix issue #106 by adding parameters `--all-connections` activated by default and desactivated when you give a `--connection` parameter.

if you pass `--all-connections=false` the propel connection will be selected
