### PR TITLE
[task] fix build-model and build-task issue

### DIFF
--- a/lib/task/sfPropelBuildModelTask.class.php
+++ b/lib/task/sfPropelBuildModelTask.class.php
@@ -26,6 +26,9 @@ class sfPropelBuildModelTask extends sfPropelBaseTask
   protected function configure()
   {
     $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev'),
+      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
       new sfCommandOption('phing-arg', null, sfCommandOption::PARAMETER_REQUIRED | sfCommandOption::IS_ARRAY, 'Arbitrary phing argument'),
     ));
 

--- a/lib/task/sfPropelBuildSqlTask.class.php
+++ b/lib/task/sfPropelBuildSqlTask.class.php
@@ -26,6 +26,9 @@ class sfPropelBuildSqlTask extends sfPropelBaseTask
   protected function configure()
   {
     $this->addOptions(array(
+      new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
+      new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environment', 'dev'),
+      new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
       new sfCommandOption('phing-arg', null, sfCommandOption::PARAMETER_REQUIRED | sfCommandOption::IS_ARRAY, 'Arbitrary phing argument'),
     ));
 


### PR DESCRIPTION
Fix build-model and build-sql task

Issue occured when we use secret.yml for logins and password with application dependencies. In this case our databases.yml file use constantes.

Whithout this fix we are getting this error:

```
[propel-om] Loading XML schema files...
[PHP Error] include_once(platform/Platform.php): failed to open stream: No such file or directory [line 1006 of .../plugins/sfPropelORMPlugin/lib/vendor/phing/classes/phing/Phing.php]

...

[phingcall] Error importing platform/Platform.php
Execution of target "om" failed for the following reason: .../plugins/sfPropelORMPlugin/lib/vendor/propel/generator/build-propel.xml:525:22: Execution of the target buildfile failed. Aborting.
    [phing] .../plugins/sfPropelORMPlugin/lib/vendor/propel/generator/build-propel.xml:525:22: Execution of the target buildfile failed. Aborting.
```
