### PR TITLE
Batch deletetion of nested set objects

### DIFF
--- a/data/generator/sfPropelModule/admin/parts/batchAction.php
+++ b/data/generator/sfPropelModule/admin/parts/batchAction.php
@@ -52,10 +52,22 @@
     {
       $this->dispatcher->notify(new sfEvent($this, 'admin.delete_object', array('object' => $object)));
 
-      // reload the object if it's in a tree to avoid breaking nested set structure
+      // check if object is in a tree
       if ($count && method_exists($object, 'isInTree') && $object->isInTree())
       {
-        $object->reload();
+        // test if we can reload an object
+        try
+        {
+          $object->reload(); // reload to avoid breaking nested set structure
+        }
+        catch (Exception $e)
+        {
+          // will fail if object does not exist in the database anymore
+          // happens when trying to delete children of already deleted object
+          // so increase the counter and move on
+          $count++;
+          continue;
+        }
       }
 
       $object->delete();

--- a/data/generator/sfPropelModule/admin15/parts/batchAction.php
+++ b/data/generator/sfPropelModule/admin15/parts/batchAction.php
@@ -52,10 +52,22 @@
     {
       $this->dispatcher->notify(new sfEvent($this, 'admin.delete_object', array('object' => $object)));
 
-      // reload the object if it's in a tree to avoid breaking nested set structure
+      // check if object is in a tree
       if ($count && method_exists($object, 'isInTree') && $object->isInTree())
       {
-        $object->reload();
+        // test if we can reload an object
+        try
+        {
+          $object->reload(); // reload to avoid breaking nested set structure
+        }
+        catch (Exception $e)
+        {
+          // will fail if object does not exist in the database anymore
+          // happens when trying to delete children of already deleted object
+          // so increase the counter and move on
+          $count++;
+          continue;
+        }
       }
 
       $object->delete();


### PR DESCRIPTION
When removing nested set objects via batchDelete, there can be possible tree corruption.

Objects are retrieved only once and every time one of them is deleted, nested structure changes but it's not updated for objects in memory:

``` php

<?php
    $count = 0;
    foreach (MapPeer::retrieveByPks($ids) as $object)
    {
      $this->dispatcher->notify(new sfEvent($this, 'admin.delete_object', array('object' => $object)));

      $object->delete();
      if ($object->isDeleted())
      {
        $count++;
      }
    }
```

The simple fix is to reload each object before deletion:

``` php

<?php
    $count = 0;
    foreach (MapPeer::retrieveByPks($ids) as $object)
    {
      $this->dispatcher->notify(new sfEvent($this, 'admin.delete_object', array('object' => $object)));

      // reload the object if it's in a tree to avoid breaking nested set structure
      if ($count && method_exists($object, 'isInTree') && $object->isInTree())
      {
        $object->reload();
      }

      $object->delete();
      if ($object->isDeleted())
      {
        $count++;
      }
    }
```

Note: we don't need to reload first object since there were no changes yet.
