### PR TITLE
move js from render() to decorator js, because...

### DIFF
--- a/lib/widget/sfWidgetFormSchemaOptional.class.php
+++ b/lib/widget/sfWidgetFormSchemaOptional.class.php
@@ -63,6 +63,7 @@ function add{$strippedName}Widget()
 {
   added{$strippedName} += 1;
   var content = \"{$decorator}\";
+  var {$strippedName}Js = \"{$this->widgetJsString}\";
   var spanTag = document.createElement(\"span\");
   spanTag.innerHTML = content.replace(/([_\[]){$strippedName}([_\]])/g, '\$1{$strippedName}' +  + added{$strippedName} + '\$2');
   document.getElementById('add_{$strippedName}').appendChild(spanTag);


### PR DESCRIPTION
move js from render() to decorator js, because if the form contains widgets with js, then it will not work, at least not in all browsers.
