### PR TITLE
Backported the PR #110 from PropelBundle

### DIFF
--- a/lib/addon/sfPropelData.class.php
+++ b/lib/addon/sfPropelData.class.php
@@ -147,12 +147,25 @@ class sfPropelData extends sfData
 
         foreach ($data as $name => $value)
         {
-          if (is_array($value) && 's' == substr($name, -1))
+          try
           {
-            // many to many relationship
-            $this->loadMany2Many($obj, substr($name, 0, -1), $value);
-
-            continue;
+            if (is_array($value) && 's' == substr($name, -1))
+            {
+              // many to many relationship
+              $this->loadMany2Many($obj, substr($name, 0, -1), $value);
+              continue;
+            }
+          }
+          catch (PropelException $e)
+          {
+            // Check whether this is actually an array stored in the object.
+            if ('Cannot fetch TableMap for undefined table: '.substr($name, 0, -1) === $e->getMessage())
+            {
+              if ($tableMap->getColumn($name)->getType() !== 'ARRAY')
+              {
+                throw $e;
+              }
+            }
           }
 
           $isARealColumn = true;
@@ -481,6 +494,12 @@ class sfPropelData extends sfData
               }
               elseif (!$isPrimaryKey || ($isPrimaryKey && !$tableMap->isUseIdGenerator()))
               {
+                if (!empty($row[$col]) && 'ARRAY' === $column->getType())
+                {
+                  $serialized = substr($row[$col], 2, -2);
+                  $row[$col] = $serialized ? explode(' | ', $serialized) : array();
+                }
+
                 // We did not want auto incremented primary keys
                 $values[$col] = $row[$col];
               }

--- a/test/functional/fixtures/config/schema.xml
+++ b/test/functional/fixtures/config/schema.xml
@@ -43,6 +43,7 @@
   <table name="author">
     <column name="id" type="integer" required="true" primaryKey="true" autoincrement="true" />
     <column name="name" type="varchar" size="255" />
+    <column name="hobbies" type="array" required="false" />
   </table>
 
   <table name="author_article">

--- a/test/functional/fixtures/data/fixtures/fixtures.yml
+++ b/test/functional/fixtures/data/fixtures/fixtures.yml
@@ -30,6 +30,7 @@ Author:
   fabien:
     name: Fabien
     author_articles: [article_1, article_2]
+    hobbies:         ['foo', 'bar']
   thomas:
     name: Thomas
     author_articles: [article_1]

--- a/test/functional/task/loadDataTest.php
+++ b/test/functional/task/loadDataTest.php
@@ -1,0 +1,17 @@
+<?php
+
+$app = 'frontend';
+$fixtures = 'fixtures/fixtures.yml';
+require_once dirname(__FILE__).'/../../bootstrap/functional.php';
+
+$browser = new sfTestFunctional(new sfBrowser(), null, array(
+  'propel' => 'sfTesterPropel'
+));
+
+
+$browser->info('Check that ARRAY columns are loaded');
+$criteria = AuthorQuery::create()
+  ->filterByHobbies(array('foo', 'bar'), Criteria::CONTAINS_ALL);
+$browser->with('propel')->begin()->
+  check('Author', $criteria)->
+end();


### PR DESCRIPTION
Which fixes the handling of array type in data loader ([see here](https://github.com/propelorm/PropelBundle/pull/110) for the original PR)
