### PR TITLE
made test installer cross platform

### DIFF
--- a/test/bin/installer.php
+++ b/test/bin/installer.php
@@ -29,16 +29,16 @@ $fs->execute(sprintf('cd %s && git submodule update --init --recursive', $plugin
 sfSymfonyPluginManager::enablePlugin('sfPropelORMPlugin', sfConfig::get('sf_config_dir'));
 
 $this->logSection('install', 'setup propel behavior');
-$ini_file = sfConfig::get('sf_config_dir').'/propel.ini';
+$ini_file = sfConfig::get('sf_config_dir'). DIRECTORY_SEPARATOR . 'propel.ini';
 $content = file_get_contents($ini_file);
 preg_replace('#^propel.behavior#', ';\1', $content);
 $content .= <<<EOF
 propel.behavior.default                        = symfony,symfony_i18n
-propel.behavior.symfony.class                  = plugins.sfPropel15Plugin.lib.behavior.SfPropelBehaviorSymfony
-propel.behavior.symfony_i18n.class             = plugins.sfPropel15Plugin.lib.behavior.SfPropelBehaviorI18n
-propel.behavior.symfony_i18n_translation.class = plugins.sfPropel15Plugin.lib.behavior.SfPropelBehaviorI18nTranslation
-propel.behavior.symfony_behaviors.class        = plugins.sfPropel15Plugin.lib.behavior.SfPropelBehaviorSymfonyBehaviors
-propel.behavior.symfony_timestampable.class    = plugins.sfPropel15Plugin.lib.behavior.SfPropelBehaviorTimestampable
+propel.behavior.symfony.class                  = plugins.sfPropelORMPlugin.lib.behavior.SfPropelBehaviorSymfony
+propel.behavior.symfony_i18n.class             = plugins.sfPropelORMPlugin.lib.behavior.SfPropelBehaviorI18n
+propel.behavior.symfony_i18n_translation.class = plugins.sfPropelORMPlugin.lib.behavior.SfPropelBehaviorI18nTranslation
+propel.behavior.symfony_behaviors.class        = plugins.sfPropelORMPlugin.lib.behavior.SfPropelBehaviorSymfonyBehaviors
+propel.behavior.symfony_timestampable.class    = plugins.sfPropelORMPlugin.lib.behavior.SfPropelBehaviorTimestampable
 EOF;
 
 file_put_contents($ini_file, $content);


### PR DESCRIPTION
I change the test installer.php to make it cross platform (work on my windows 7 and on travis-ci)

[![Build Status](https://secure.travis-ci.org/jaugustin/sfPropelORMPlugin.png?branch=test-installer-cross-platform)](http://travis-ci.org/jaugustin/sfPropelORMPlugin)

This will help me to write and fix tests for #90 ;)

prepare_tests.sh is still unix only but it work on my git bash ;)
