### PR TITLE
Add sfFileCache for databaseMap with sfPropelData to load faster each tests

### DIFF
--- a/lib/addon/sfPropelData.class.php
+++ b/lib/addon/sfPropelData.class.php
@@ -26,6 +26,20 @@ class sfPropelData extends sfData
     $formatter      = null;
 
   /**
+   * @var int The cache duration
+   */
+  protected $cacheKeepDuration;
+
+  public function __construct($cacheKeepDuration = 7200)
+  {
+    $this->cache = new sfFileCache(array(
+      'cache_dir' => sfConfig::get('sf_cache_dir')
+    ));
+
+    $this->cacheKeepDuration = $cacheKeepDuration;
+  }
+
+  /**
    * Initializes the sfPropelData instance.
    *
    * @param sfEventDispatcher $dispatcher  A sfEventDispatcher instance
@@ -313,23 +327,34 @@ class sfPropelData extends sfData
   }
 
   /**
-   * Loads all map builders.
+   * Loads all map builders for a given connection name
+   *
+   * Use sfFileCache to cache propel databaseMap
    *
    * @throws sfException If the class cannot be found
    */
   protected function loadMapBuilders($connectionName)
   {
-    $dbMap = Propel::getDatabaseMap();
-    $files = sfFinder::type('file')->name('*TableMap.php')->in(sfProjectConfiguration::getActive()->getModelDirs());
-    foreach ($files as $file)
+    $cacheKey = 'dbMap-' . $connectionName;
+
+    if(!$dbMap = $this->cache->get($cacheKey))
     {
-      $omClass = basename($file, 'TableMap.php');
-      if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject') && constant($omClass.'Peer::DATABASE_NAME') == $connectionName)
+      $dbMap = Propel::getDatabaseMap();
+      $files = sfFinder::type('file')->name('*TableMap.php')->in(sfProjectConfiguration::getActive()->getModelDirs());
+      foreach ($files as $file)
       {
-        $tableMapClass = basename($file, '.php');
-        $dbMap->addTableFromMapClass($tableMapClass);
+        $omClass = basename($file, 'TableMap.php');
+        if (class_exists($omClass) && is_subclass_of($omClass, 'BaseObject') && constant($omClass.'Peer::DATABASE_NAME') == $connectionName)
+        {
+          $tableMapClass = basename($file, '.php');
+          $dbMap->addTableFromMapClass($tableMapClass);
+        }
       }
+
+      $dbMap = serialize($dbMap);
+      $this->cache->set($cacheKey, $dbMap, $this->cacheKeepDuration);
     }
+    Propel::setDatabaseMap($connectionName, unserialize($dbMap));
   }
 
   /**


### PR DESCRIPTION
When we use `sfPropelData` in more than one test, we reload each time all dbMaps. This PR implement a way to store in sfFileCache to prevent multiple calculation and browse of all the file tree

cc @arlo
