### PR TITLE
propel.ini default dsn

### DIFF
--- a/config/skeleton/config/propel.ini
+++ b/config/skeleton/config/propel.ini
@@ -3,7 +3,7 @@ propel.packageObjectModel  = true
 propel.project             = ##PROJECT_NAME##
 propel.database            = mysql
 propel.database.driver     = mysql
-propel.database.url        = mysql:dbname=##PROJECT_NAME##;host=localhost
+propel.database.url        = 'mysql:dbname=##PROJECT_NAME##;host=localhost'
 propel.database.creole.url = ${propel.database.url}
 propel.database.user       = root
 propel.database.password   = 


### PR DESCRIPTION
I had the same problem as the guy here :
http://groups.google.com/group/propel-users/browse_thread/thread/099a8bd3d18441cf

I propose to integrate it in skeleton propel.ini
