### PR TITLE
Fix: fixtures loading with single inheritance

### DIFF
--- a/lib/addon/sfPropelData.class.php
+++ b/lib/addon/sfPropelData.class.php
@@ -224,7 +224,9 @@ class sfPropelData extends sfData
         // save the object for future reference
         if (method_exists($obj, 'getPrimaryKey'))
         {
-          $this->object_references[$class.'_'.$key] = $obj;
+          $peer = $class::PEER;
+          $class_key = $peer::OM_CLASS;
+          $this->object_references[$class_key.'_'.$key] = $obj;
         }
       }
     }


### PR DESCRIPTION
I wasn't able to load fixtures with inheritance because when I
defined a Novel in my fixtures (which extends Book), it would be saved
by the sfPropelData class in a 'object_references' property under the
'%class%_%pk%' key (Novel_42 for instance).

Unfortunately, if I reference later in my fixtures this novel, the class
would look up in the cache but with the wrong key (it would use Book_42).
