### PR TITLE
Fix for using platform class configured in build properties

### DIFF
--- a/lib/task/sfPropelDiffTask.class.php
+++ b/lib/task/sfPropelDiffTask.class.php
@@ -81,7 +81,7 @@ EOF;
       }
       $pdo = $databaseManager->getDatabase($name)->getConnection();
       $database = new Database($name);
-      $platform = $this->getPlatform($databaseManager, $name);
+      $platform = $this->getGeneratorConfig()->getConfiguredPlatform($pdo, $name);
       $database->setPlatform($platform);
       $database->setDefaultIdMethod(IDMethod::NATIVE);
       $parser = $this->getParser($databaseManager, $name, $pdo);


### PR DESCRIPTION
Fix related to https://github.com/propelorm/Propel/pull/407 for using platform class configured in build properties
