### PR TITLE
sfPropelMigrateTask: returns invalid value when there is nothing to migrate

### DIFF
--- a/lib/task/sfPropelMigrateDownTask.class.php
+++ b/lib/task/sfPropelMigrateDownTask.class.php
@@ -64,7 +64,7 @@ EOF;
     if (!$nextMigrationTimestamp = array_pop($previousTimestamps))
     {
       $this->logSection('propel', 'No migration were ever executed on this database - nothing to reverse.');
-      return false;
+      return true;
     }
     $this->logSection('propel', sprintf(
       'Executing migration %s down',
@@ -150,6 +150,8 @@ EOF;
     {
       $this->logSection('propel', 'Reverse migration complete. No more migration available for reverse');
     }
+
+    return true;
   }
 
 }

--- a/lib/task/sfPropelMigrateTask.class.php
+++ b/lib/task/sfPropelMigrateTask.class.php
@@ -63,7 +63,7 @@ EOF;
     if (!$nextMigrationTimestamp = $manager->getFirstUpMigrationTimestamp())
     {
       $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
-      return null;
+      return true;
     }
 
     $timestamps = $manager->getValidMigrationTimestamps();
@@ -142,6 +142,8 @@ EOF;
     }
 
     $this->logSection('propel', 'Migration complete. No further migration to execute.');
+
+    return true;
   }
 
 }

--- a/lib/task/sfPropelMigrateUpTask.class.php
+++ b/lib/task/sfPropelMigrateUpTask.class.php
@@ -63,7 +63,7 @@ EOF;
     if (!$nextMigrationTimestamp = $manager->getFirstUpMigrationTimestamp())
     {
       $this->logSection('propel', 'All migrations were already executed - nothing to migrate.');
-      return false;
+      return true;
     }
     $this->logSection('propel', sprintf(
       'Executing migration %s up',
@@ -142,6 +142,8 @@ EOF;
     {
       $this->logSection('propel', 'Migration complete. No further migration to execute.');
     }
+
+    return true;
   }
 
 }


### PR DESCRIPTION
Tasks returns **_null**_ on success so we can identify there was an error:

``` php
<?php
$task = new sfPropelMigrateTask($this->dispatcher, new sfFormatter());
if($task->run() !== null){
  // ooops! en error occurred!
}
```

But **sfPropelMigrateTask** returned **_false**_ not only on error but even when there was nothing to migrate.
I believe it's not an error so simple change **_false**_ to **_null**_ fixes this issue.
