### PR TITLE
fix for symfony project:validate task - sfPropelAdminGenerator is deprecated class

### DIFF
--- a/test/functional/fixtures/apps/backend_compat/modules/article/config/generator.yml
+++ b/test/functional/fixtures/apps/backend_compat/modules/article/config/generator.yml
@@ -1,5 +1,5 @@
 generator:
-  class:              sfPropelAdminGenerator
+  class:              sfPropelGenerator
   param:
     model_class:      Article
     theme:            default

--- a/test/functional/fixtures/apps/backend_compat/modules/error/config/generator.yml
+++ b/test/functional/fixtures/apps/backend_compat/modules/error/config/generator.yml
@@ -1,5 +1,5 @@
 generator:
-  class:              sfPropelAdminGenerator
+  class:              sfPropelGenerator
   param:
     model_class:      FakeClass
     theme:            default

--- a/test/functional/fixtures/apps/backend_compat/modules/inheritance/config/generator.yml
+++ b/test/functional/fixtures/apps/backend_compat/modules/inheritance/config/generator.yml
@@ -1,5 +1,5 @@
 generator:
-  class:              sfPropelAdminGenerator
+  class:              sfPropelGenerator
   param:
     model_class:      Article
     theme:            default

--- a/test/functional/fixtures/apps/backend_compat/modules/validation/config/generator.yml
+++ b/test/functional/fixtures/apps/backend_compat/modules/validation/config/generator.yml
@@ -1,5 +1,5 @@
 generator:
-  class:              sfPropelAdminGenerator
+  class:              sfPropelGenerator
   param:
     model_class:      Article
     theme:            default


### PR DESCRIPTION
Hi,

Usage of deprecated class generates some noise in symfony project:validate task.

Best regards,
Michal
