### PR TITLE
Fix broken path in include_path

### DIFF
--- a/lib/task/sfPropelBaseTask.class.php
+++ b/lib/task/sfPropelBaseTask.class.php
@@ -246,7 +246,7 @@ abstract class sfPropelBaseTask extends sfBaseTask
     // Call phing targets
     sfToolkit::addIncludePath(array(
       sfConfig::get('sf_symfony_lib_dir'),
-      sfConfig::get('sf_propel_generator_path', sfConfig::get('sf_propel_path').'generator/lib'),
+      sfConfig::get('sf_propel_generator_path', sfConfig::get('sf_propel_path').'/generator/lib'),
     ));
 
     $args = array();


### PR DESCRIPTION
This fixes a fatal error occurring when I run ./symfony propel:build-model in sfPropelORMPlugin master.

`Fatal error: require_once(): Failed opening required 'task/AbstractPropelDataModelTask.php'
in /var/local/webroot/move/plugins/sfPropelORMPlugin/lib/vendor/propel/generator/lib/task/PropelOMTask.php on line 11`

Strangely, the code seems broken since 2011-08.
