### PR TITLE
Fix support for refPhpName, keep BC with fkRefPhpName.

### DIFF
--- a/doc/schema.md
+++ b/doc/schema.md
@@ -130,7 +130,7 @@ Foreign key columns accept additional parameters:
   * `foreignReference`: The name of the related column if a foreign key is defined via `foreignTable`.
   * `onDelete`: Determines the action to trigger when a record in a related table is deleted. When set to `setnull`, the foreign key column is set to `null`. When set to `cascade`, the record is deleted. If the database engine doesn't support the set behavior, the ORM emulates it.
   * `fkPhpName`: Name of the related object seen from the current object. Propel uses this name to generate filters and accessors (see the 'Relation Names' section below)
-  * `fkRefPhpName`: Name of the current object seen from the related object.
+  * `refPhpName`: Name of the current object seen from the related object.
   * `fkSkipSql`: Set to true for virtual foreign keys, not translated into SQL
 
 ### Empty Column Definition
@@ -389,7 +389,7 @@ Here, Propel creates a `User` relation on the `Book` object, and a `Book` relati
       ->filterByUser($user)
       ->find();
 
-You may want to customize the relation names to qualify the relationship. In the previous example, when related to an `Article`, a `User` would better be called an `Author`. Symmetrically, from the `User` point of view, a `Book` should be named a `Work`. Use the `fkPhpName` and `fkRefPhpName` column attributes to choose custom relation names:
+You may want to customize the relation names to qualify the relationship. In the previous example, when related to an `Article`, a `User` would better be called an `Author`. Symmetrically, from the `User` point of view, a `Book` should be named a `Work`. Use the `fkPhpName` and `refPhpName` column attributes to choose custom relation names:
 
     [yaml]
     propel:
@@ -398,7 +398,7 @@ You may want to customize the relation names to qualify the relationship. In the
         id:          ~
         title:       varchar(150)
         body:        longvarchar
-        user_id:     { fkPhpName: Author, fkRefPhpName: Work, type: integer, foreignTable: user, foreignReference: id, onDelete: cascade }
+        user_id:     { fkPhpName: Author, refPhpName: Work, type: integer, foreignTable: user, foreignReference: id, onDelete: cascade }
 
 Now the generated code looks like this:
 

--- a/lib/addon/sfPropelDatabaseSchema.class.php
+++ b/lib/addon/sfPropelDatabaseSchema.class.php
@@ -804,7 +804,7 @@ class sfPropelDatabaseSchema
     {
       foreach ($column as $key => $value)
       {
-        if (!in_array($key, array('foreignClass', 'foreignTable', 'foreignReference', 'fkPhpName', 'fkRefPhpName', 'fkSkipSql', 'onDelete', 'onUpdate', 'index', 'unique', 'sequence', 'inheritance', 'vendor')))
+        if (!in_array($key, array('foreignClass', 'foreignTable', 'foreignReference', 'fkPhpName', 'refPhpName', 'fkRefPhpName', 'fkSkipSql', 'onDelete', 'onUpdate', 'index', 'unique', 'sequence', 'inheritance', 'vendor')))
         {
           $attributes_string .= " $key=\"".htmlspecialchars($this->getCorrectValueFor($key, $value), ENT_QUOTES, sfConfig::get('sf_charset'))."\"";
         }
@@ -893,9 +893,13 @@ class sfPropelDatabaseSchema
       {
         $attributes_string .= " phpName=\"{$column['fkPhpName']}\"";
       }
-      if (isset($column['fkRefPhpName']))
+      if (isset($column['refPhpName']))
       {
-        $attributes_string .= " refPhpName=\"{$column['fkRefPhpName']}\"";
+        $attributes_string .= " refPhpName=\"{$column['refPhpName']}\"";
+      }
+      elseif (isset($column['fkRefPhpName']))
+      {
+          $attributes_string .= " refPhpName=\"{$column['fkRefPhpName']}\"";
       }
       if (isset($column['fkSkipSql']))
       {

--- a/test/unit/fixtures/new_schema.yml
+++ b/test/unit/fixtures/new_schema.yml
@@ -45,7 +45,7 @@ classes:
       stripped_title: { type: longvarchar, required: true, primaryKey: true, sequence: my_custom_sequence_name }
       user_id:
       my_group:       { type: integer, foreignTable: ab_group, foreignReference: id, onDelete: setnull }
-      my_other_group: { type: integer, foreignTable: ab_group, foreignReference: id, onDelete: setnull, phpName: MyOtherGroupPhpName, fkPhpName: MyOtherGroupFkPhpName, fkRefPhpName: MyOtherGroupFkRefPhpName }
+      my_other_group: { type: integer, foreignTable: ab_group, foreignReference: id, onDelete: setnull, phpName: MyOtherGroupPhpName, fkPhpName: MyOtherGroupFkPhpName, refPhpName: MyOtherGroupRefPhpName }
       created_at:     timestamp
       updated_at:
 

--- a/test/unit/fixtures/schema.xml
+++ b/test/unit/fixtures/schema.xml
@@ -57,7 +57,7 @@
       <reference local="my_group" foreign="id" />
     </foreign-key>
     <column name="my_other_group" type="integer" phpName="MyOtherGroupPhpName" />
-    <foreign-key foreignTable="ab_group" onDelete="setnull" phpName="MyOtherGroupFkPhpName" refPhpName="MyOtherGroupFkRefPhpName">
+    <foreign-key foreignTable="ab_group" onDelete="setnull" phpName="MyOtherGroupFkPhpName" refPhpName="MyOtherGroupRefPhpName">
       <reference local="my_other_group" foreign="id" />
     </foreign-key>
     <column name="created_at" type="timestamp" />

--- a/test/unit/fixtures/schema.yml
+++ b/test/unit/fixtures/schema.yml
@@ -34,7 +34,7 @@ propel:
     stripped_title: { type: longvarchar, required: true, primaryKey: true, sequence: my_custom_sequence_name }
     user_id:
     my_group:       { type: integer, foreignTable: ab_group, foreignReference: id, onDelete: setnull }
-    my_other_group: { type: integer, foreignTable: ab_group, foreignReference: id, onDelete: setnull, phpName: MyOtherGroupPhpName, fkPhpName: MyOtherGroupFkPhpName, fkRefPhpName: MyOtherGroupFkRefPhpName }
+    my_other_group: { type: integer, foreignTable: ab_group, foreignReference: id, onDelete: setnull, phpName: MyOtherGroupPhpName, fkPhpName: MyOtherGroupFkPhpName, refPhpName: MyOtherGroupRefPhpName }
     created_at:     timestamp
     updated_at:
 


### PR DESCRIPTION
I noticed my pull request
https://github.com/propelorm/propelorm.github.com/pull/159
was reverted by
https://github.com/propelorm/propelorm.github.com/pull/159

Turns out the problem is not in Propel but in the symfony plugin.
This patch adds refPhpName support in the plugin, and keeps BC by still supporting fkRefPhpName.
