### PR TITLE
tablePrefix and phpName in schema.yml

### DIFF
--- a/lib/addon/sfPropelDatabaseSchema.class.php
+++ b/lib/addon/sfPropelDatabaseSchema.class.php
@@ -290,10 +290,7 @@ class sfPropelDatabaseSchema
           $tableName = sfInflector::underscore($className);
         }
 
-        if (sfInflector::camelize($tableName) != $className)
-        {
-          $tableAttributes['phpName'] = $className;
-        }
+        $tableAttributes['phpName'] = $className;
 
         if ($tableAttributes || $classParams)
         {


### PR DESCRIPTION
I would use the "tablePrefix" attribute in the main configuration of the schema.yml

I'm using the "phpName" attribute on each table to do not add the prefix to the generated classname. 
As the phpName is the same as the table_name (before prefix is added), the "phpName" attribute is not written to the "generated-schema.xml" file.

<pre>
propel:
  _attributes:
    package: lib.model
    defaultPhpNamingMethod: phpname
    table_prefix: cds_

    atlas:
      _attributes: { phpName: Atlas }
      id: ~
      name: { type: varchar, size: 50 }
</pre>


Generated class files are
- CdsAtlas.php
- CdsAtlasQuery.php
- CdsAtlasPeer.php

and I assume they should be
- Atlas.php
- AtlasQuery.php
- AtlasPeer.php

Sorry for my english.
