### PR TITLE
adds connection to pager and route

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,14 @@ public function executeShow(sfWebRequest $request)
     $this->author = $this->getRoute()->getAuthor();
 }
 ```
+
+A new option has been added to `sfPropelORMRoute`: the `connection` option allows to set a specific Propel connection to use.
+Example:
+
+``` yaml
+author_show:
+  url:     /author/:id
+  class:   Author
+  param:   { module: myModule, action: show }
+  options: { model: Author, type: object, connection: my_connection }
+```

--- a/lib/addon/sfPropelPager.class.php
+++ b/lib/addon/sfPropelPager.class.php
@@ -21,6 +21,7 @@ class sfPropelPager extends sfPager
 {
   protected
     $criteria               = null,
+    $con                    = null,
     $peer_method_name       = 'doSelect',
     $peer_count_method_name = 'doCount';
 
@@ -40,8 +41,9 @@ class sfPropelPager extends sfPager
   /**
    * @see sfPager
    */
-  public function init()
+  public function init($con = null)
   {
+    $this->con = $con;
     $this->results = null;
 
     $hasMaxRecordLimit = ($this->getMaxRecordLimit() !== false);
@@ -54,7 +56,7 @@ class sfPropelPager extends sfPager
       ->clearGroupByColumns()
     ;
 
-    $count = call_user_func(array($this->getClassPeer(), $this->getPeerCountMethod()), $criteriaForCount);
+    $count = call_user_func(array($this->getClassPeer(), $this->getPeerCountMethod()), $criteriaForCount, false, $this->con);
 
     $this->setNbResults($hasMaxRecordLimit ? min($count, $maxRecordLimit) : $count);
 
@@ -104,7 +106,7 @@ class sfPropelPager extends sfPager
       ->setLimit(1)
     ;
 
-    $results = call_user_func(array($this->getClassPeer(), $this->getPeerMethod()), $criteriaForRetrieve);
+    $results = call_user_func(array($this->getClassPeer(), $this->getPeerMethod()), $criteriaForRetrieve, $this->con);
 
     return is_array($results) && isset($results[0]) ? $results[0] : null;
   }
@@ -114,7 +116,7 @@ class sfPropelPager extends sfPager
    */
   public function getResults()
   {
-    return call_user_func(array($this->getClassPeer(), $this->getPeerMethod()), $this->getCriteria());
+    return call_user_func(array($this->getClassPeer(), $this->getPeerMethod()), $this->getCriteria(), $this->con);
   }
 
   /**

--- a/lib/routing/sfPropelORMRoute.class.php
+++ b/lib/routing/sfPropelORMRoute.class.php
@@ -106,7 +106,8 @@ class sfPropelORMRoute extends sfObjectRoute
     }
 
     // check the related object
-    $this->object = $this->getQuery()->findOne();
+    $con = empty($this->options['connection']) ? null : Propel::getConnection($this->options['connection']);
+    $this->object = $this->getQuery()->findOne($con);
 
     if (!$this->object && (!isset($this->options['allow_empty']) || !$this->options['allow_empty']))
     {


### PR DESCRIPTION
I found that sfPropelPager has no support for connections (other tnan default, of course). So I implemented a small change, that adds a $con parameter (just the same as PropelModelPager) and uses it for queries.
About route: I just addedd a new option to be able to use a sfPropelORMRoute with a different connection. Also updated doc about it.
