### PR TITLE
Add the possibility to change the default label of a embedded realtion from new<RelationName> to an arbitrary name

### DIFF
--- a/lib/form/sfFormPropel.class.php
+++ b/lib/form/sfFormPropel.class.php
@@ -549,6 +549,7 @@ abstract class sfFormPropel extends sfFormObject
    *  - title: The title of the collection form once embedded. Defaults to the relation name.
    *  - decorator: The decorator for the sfWidgetFormSchemaDecorator
    *  - add_empty: Whether to allow the user to add new objects to the collection. Defaults to true
+   *  - empty_name: Label showed to create a new related item. By default is new + name of the relation
    * Additional options are passed to sfFromPropel::getRelationForm()
    *  - empty_label: The label of the empty form
    *
@@ -564,12 +565,13 @@ abstract class sfFormPropel extends sfFormObject
       'decorator'           => null,
       'add_empty'           => true,
       'max_additions'       => 0,
+      'empty_name'          => 'new'.$relationName,
       'empty_label'         => null,
     ), $options);
 
     $relationForm = $this->getRelationForm($relationName, $options);
 
-    $this->addEmptyRelationForm($relationName, $relationForm, 'new' . $relationName, $relationName. '/', $options);
+    $this->addEmptyRelationForm($relationName, $relationForm, 'new'.$relationName, $relationName. '/', $options);
 
     $this->embedForm($relationName, $relationForm, $options['decorator']);
 
@@ -577,6 +579,7 @@ abstract class sfFormPropel extends sfFormObject
 
     return $this;
   }
+
 
   /**
    * Get a Collection form based on a Relation of the current form's model.
@@ -669,6 +672,7 @@ abstract class sfFormPropel extends sfFormObject
       $options['max_additions'] = $options['max_additions'] - $count;
     }
     $emptyForm = $this->getEmptyRelatedForm($relationName, $options);
+    $emptyForm->widgetSchema->setLabel($options['empty_name']);
     $relationForm->embedOptionalForm($emptyName, $emptyForm, $options['empty_decorator'], $options);
     $this->optionalForms[$prefix . $emptyName] = $emptyForm;
   }


### PR DESCRIPTION
If you are a non english speaker (or your customer), when you embed a relation in a form always get **new<RelationName>** as a label in the related form when you allow to add empty objects. In this case, you can pass a new option named **'empty_name'** with the label that you want for the new object. 

Example of use:

``` php
    $this->embedRelation('ConcursoPatrocinador',
                         array('title' => 'Patrocinadores',
                               'empty_name' => 'Nuevo patrocinador',
                               'add_link'   => 'Añadir patrocinador,
                               'add_empty' => true));
```

without empty_name:
![default_label](https://f.cloud.github.com/assets/664229/78843/66ed86a4-6195-11e2-9fbc-b38d2bd84602.jpg)

with empty_name:
![nuveo_pat](https://f.cloud.github.com/assets/664229/78834/322e4322-6195-11e2-8c9a-5177353ce891.jpg)
