### PR TITLE
Update data/generator/sfPropelModule/admin15/template/lib/helper.php

### DIFF
--- a/data/generator/sfPropelModule/admin15/template/lib/helper.php
+++ b/data/generator/sfPropelModule/admin15/template/lib/helper.php
@@ -26,7 +26,7 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorHelper 
       $params['action'] = 'moveUp';
     }
 
-    return '<li class="sf_admin_action_moveup">'.link_to(__($params['label'], array(), 'sf_admin'), '<?php echo $this->params['route_prefix'] ?>/'.$params['action'].'?<?php echo $this->getPrimaryKeyUrlParams('$object', true); ?>).'</li>';
+    return '<li class="sf_admin_action_moveup">'.link_to(__($params['label'], array(), 'sf_admin'), '<?php echo $this->params['moduleName'] ?>/'.$params['action'].'?<?php echo $this->getPrimaryKeyUrlParams('$object', true); ?>).'</li>';
   }
 
   public function linkToMoveDown($object, $params)
@@ -41,7 +41,7 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorHelper 
       $params['action'] = 'moveDown';
     }
 
-    return '<li class="sf_admin_action_movedown">'.link_to(__($params['label'], array(), 'sf_admin'), '<?php echo $this->params['route_prefix'] ?>/'.$params['action'].'?<?php echo $this->getPrimaryKeyUrlParams('$object', true); ?>).'</li>';
+    return '<li class="sf_admin_action_movedown">'.link_to(__($params['label'], array(), 'sf_admin'), '<?php echo $this->params['moduleName'] ?>/'.$params['action'].'?<?php echo $this->getPrimaryKeyUrlParams('$object', true); ?>).'</li>';
   }
 
 }


### PR DESCRIPTION
Fixed module generator Helper template.

Now it uses `params['moduleName']` instead of `params['route_prefix']` for url generation.
`url_for` supports `module/action` instead of route name to generate url.

All was fine when `route_prefix` was equal to `moduleName`. But in other cases we've got an error while generating url for _moveUp_ and _moveDown_ actions.
