### PR TITLE
Fixed a little typo in dump task

### DIFF
--- a/lib/task/sfPropelDataDumpTask.class.php
+++ b/lib/task/sfPropelDataDumpTask.class.php
@@ -33,7 +33,7 @@ class sfPropelDataDumpTask extends sfPropelBaseTask
       new sfCommandOption('application', null, sfCommandOption::PARAMETER_OPTIONAL, 'The application name', true),
       new sfCommandOption('env', null, sfCommandOption::PARAMETER_REQUIRED, 'The environement', 'cli'),
       new sfCommandOption('connection', null, sfCommandOption::PARAMETER_REQUIRED, 'The connection name', 'propel'),
-      new sfCommandOption('classes', null, sfCommandOption::PARAMETER_REQUIRED, 'The class names to dump (separated by a colon)', null),
+      new sfCommandOption('classes', null, sfCommandOption::PARAMETER_REQUIRED, 'The class names to dump (separated by a comma)', null),
     ));
 
     $this->namespace = 'propel';


### PR DESCRIPTION
Because:

``` php
$classes = null === $options['classes'] ? 'all' : explode(',', $options['classes']);
```
