### PR TITLE
Fix generator problem when using with namespaces

### DIFF
--- a/lib/generator/sfPropelGenerator.class.php
+++ b/lib/generator/sfPropelGenerator.class.php
@@ -402,7 +402,7 @@ class sfPropelGenerator extends sfModelGenerator
 
   public function translateColumnName($column, $related = false, $to = BasePeer::TYPE_FIELDNAME)
   {
-    $peer = $related ? constant($column->getTable()->getDatabaseMap()->getTable($column->getRelatedTableName())->getPhpName().'::PEER') : constant($column->getTable()->getPhpName().'::PEER');
+    $peer = $related ? constant($column->getTable()->getDatabaseMap()->getTable($column->getRelatedTableName())->getClassName().'::PEER') : constant($column->getTable()->getClassName().'::PEER');
     $field = $related ? $column->getRelatedName() : $column->getFullyQualifiedName();
 
     return call_user_func(array($peer, 'translateFieldName'), $field, BasePeer::TYPE_COLNAME, $to);


### PR DESCRIPTION
Generator falls with error when generating admin module for model with namespaces defined.
It should use `getClassName()` instead of `getPhpName()` in this case:

Sample `schema.yml`:

``` yaml
propel:
  _attributes:
    package: lib.model.Acme.Model
    namespace: Acme\Model
  article:
    id: ~
    title: varchar
```

``` php
$map->getClassName(); // \Acme\Model\Article
$map->getPhpName(); // Article
```
