### PR TITLE
Update sfTesterPropel.class.php

### DIFF
--- a/lib/test/sfTesterPropel.class.php
+++ b/lib/test/sfTesterPropel.class.php
@@ -56,7 +56,7 @@ class sfTesterPropel extends sfTester
       {
         $column = call_user_func(array(constant($model.'::PEER'), 'translateFieldName'), $column, BasePeer::TYPE_FIELDNAME, BasePeer::TYPE_COLNAME);
         $operator = Criteria::EQUAL;
-        if ('!' == $condition[0])
+        if (!empty($condition) && '!' == $condition[0])
         {
           $operator = false !== strpos($condition, '%') ? Criteria::NOT_LIKE : Criteria::NOT_EQUAL;
           $condition = substr($condition, 1);


### PR DESCRIPTION
Added a control for $condition in check() method. Without this control, a notice is raised if passed $condition is empty, since we're trying to access its first character (that, of course, doesn't exist)
