### PR TITLE
Compatibility with Phing 2.4.13+

### DIFF
--- a/lib/task/phing/tasks/defaults.properties
+++ b/lib/task/phing/tasks/defaults.properties
@@ -19,6 +19,7 @@ cvspass=phing.tasks.system.CvsPassTask
 delete=phing.tasks.system.DeleteTask
 echo=phing.tasks.system.EchoTask
 exec=phing.tasks.system.ExecTask
+fail=phing.tasks.system.FailTask
 foreach=phing.tasks.system.ForeachTask
 includepath=phing.tasks.system.IncludePathTask
 input=phing.tasks.system.InputTask


### PR DESCRIPTION
This patch fixes compatibility with Phing 2.4.13 and newer, including 2.5.x.

Phing system task 'fail' was removed from this file in commit 9177ece, but propel generator uses this task in build-propel.xml for many years.

Phing 2.4.12 and older ignores this problem.
