### PR TITLE
Fixed case of column constant in FormFilter

### DIFF
--- a/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterGeneratedTemplate.php
+++ b/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterGeneratedTemplate.php
@@ -54,11 +54,11 @@ abstract class Base<?php echo $this->table->getClassname() ?>FormFilter extends 
     $criteria->addJoin(<?php echo constant($tables['middleTable']->getPhpName().'::PEER') ?>::<?php echo strtoupper($tables['column']->getName()) ?>, <?php echo constant($this->table->getPhpName().'::PEER') ?>::<?php echo strtoupper($this->getPrimaryKey()->getName()) ?>);
 
     $value = array_pop($values);
-    $criterion = $criteria->getNewCriterion(<?php echo constant($tables['middleTable']->getPhpName().'::PEER') ?>::<?php echo $tables['relatedColumn']->getName() ?>, $value);
+    $criterion = $criteria->getNewCriterion(<?php echo constant($tables['middleTable']->getPhpName().'::PEER') ?>::<?php echo strtoupper($tables['relatedColumn']->getName()) ?>, $value);
 
     foreach ($values as $value)
     {
-      $criterion->addOr($criteria->getNewCriterion(<?php echo constant($tables['middleTable']->getPhpName().'::PEER') ?>::<?php echo $tables['relatedColumn']->getName() ?>, $value));
+      $criterion->addOr($criteria->getNewCriterion(<?php echo constant($tables['middleTable']->getPhpName().'::PEER') ?>::<?php echo strtoupper($tables['relatedColumn']->getName()) ?>, $value));
     }
 
     $criteria->add($criterion);


### PR DESCRIPTION
Fixed column constant case when generating BaseModelFormFilter because of changed case sensitivity of columns in commit a2ff29533edecd3869ca3a1903c41f5c833c9916.

Now generated constant looks like ModelPeer::COLUMN_NAME instead of ModelPeer::column_name, which throws fatal error 'Undefined class constant' because of PHP constant case-sensitivity.
