### PR TITLE
Travis config: added php 5.2 and removed symfony 1.4.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: php
 
 php:
+    - 5.2
     - 5.3
     - 5.4
 
 env:
-    - SYMFONY_VERSION=symfony-1.4.17
     - SYMFONY_VERSION=symfony-1.4.20
 
 before_script:


### PR DESCRIPTION
There is no reason in testing old versions.
If there is .17 then why not .16? And so on.
