### PR TITLE
Added forced array type on query_methods parameter

### DIFF
--- a/lib/routing/sfPropelORMRoute.class.php
+++ b/lib/routing/sfPropelORMRoute.class.php
@@ -156,7 +156,7 @@ class sfPropelORMRoute extends sfObjectRoute
     $query = PropelQuery::from($this->options['model']);
     if (isset($this->options['query_methods']))
     {
-      foreach ($this->options['query_methods'] as $methodName => $methodParams)
+      foreach ((array)$this->options['query_methods'] as $methodName => $methodParams)
       {
         if(is_array($methodParams))
         {

--- a/lib/validator/sfValidatorPropelChoice.class.php
+++ b/lib/validator/sfValidatorPropelChoice.class.php
@@ -61,7 +61,7 @@ class sfValidatorPropelChoice extends sfValidatorBase
     {
       $criteria->mergeWith($this->getOption('criteria'));
     }
-    foreach ($this->getOption('query_methods') as $methodName => $methodParams)
+    foreach ((array)$this->getOption('query_methods') as $methodName => $methodParams)
     {
       if(is_array($methodParams))
       {

--- a/lib/validator/sfValidatorPropelUnique.class.php
+++ b/lib/validator/sfValidatorPropelUnique.class.php
@@ -92,7 +92,7 @@ class sfValidatorPropelUnique extends sfValidatorSchema
     $fields = $this->getOption('field');
 
     $criteria = PropelQuery::from($this->getOption('model'));
-    foreach ($this->getOption('query_methods') as $methodName => $methodParams)
+    foreach ((array)$this->getOption('query_methods') as $methodName => $methodParams)
     {
       if(is_array($methodParams))
       {

--- a/lib/widget/sfWidgetFormPropelChoice.class.php
+++ b/lib/widget/sfWidgetFormPropelChoice.class.php
@@ -85,7 +85,7 @@ class sfWidgetFormPropelChoice extends sfWidgetFormChoice
     {
       $criteria->mergeWith($this->getOption('criteria'));
     }
-    foreach ($this->getOption('query_methods') as $methodName => $methodParams)
+    foreach ((array)$this->getOption('query_methods') as $methodName => $methodParams)
     {
       if(is_array($methodParams))
       {


### PR DESCRIPTION
It took me a while to figure out what's wrong, had:

``` php
$this->setValidator('xxx', new sfValidatorPropelChoice(array(
    // (...)
    'query_methods' => 'someQueryMethod',
)));
```

When it should be:

``` php
$this->setValidator('xxx', new sfValidatorPropelChoice(array(
    // (...)
    'query_methods' => array('someQueryMethod'),
)));
```

Now both examples will work.
