### PR TITLE
Ability to exclude tables for migration

### DIFF
--- a/config/skeleton/config/propel.ini
+++ b/config/skeleton/config/propel.ini
@@ -45,6 +45,8 @@ propel.datadump.mapper.to      = *data.xml
 propel.builder.addComments  = true
 propel.builder.addBehaviors = true
 
+propel.migration.excludes =
+
 ; behaviors
 propel.behavior.default                        = symfony,symfony_i18n
 propel.behavior.symfony.class                  = plugins.sfPropelORMPlugin.lib.behavior.SfPropelBehaviorSymfony

--- a/lib/task/sfPropelDiffTask.class.php
+++ b/lib/task/sfPropelDiffTask.class.php
@@ -109,6 +109,26 @@ EOF;
     $this->logSection('propel', sprintf('%d tables defined in the schema files.', $appData->countTables()));
     $this->cleanup($options['verbose']);
 
+    if ($excludePatterns = $appData->getGeneratorConfig()->getBuildProperty('migrationExcludes'))
+    {
+      $excludePatterns = array_map('trim', explode(',', $excludePatterns));
+      $excludePatterns = array_map(array('sfGlobToRegex', 'glob_to_regex'), $excludePatterns);
+
+      foreach (array_merge($ad->getDatabases(), $appData->getDatabases()) as $database)
+      {
+        foreach ($database->getTables() as $table)
+        {
+          foreach ($excludePatterns as $pattern)
+          {
+            if (preg_match($pattern, $table->getName()))
+            {
+              $table->setSkipSql(true);
+            }
+          }
+        }
+      }
+    }
+
     $this->logSection('propel', 'Comparing databases and schemas...');
     $manager = new PropelMigrationManager();
     $manager->setConnections($connections);


### PR DESCRIPTION
Useful when database contains tables which does not have corresponding schema or vice versa.

This tables can be ignored by adding to config/propel.ini something like this (patterns supported):

``` ini
propel.migration.excludes = session, social_*
```
