### PR TITLE
Fixed migrations to use queries and charset settings

### DIFF
--- a/lib/task/sfPropelBaseTask.class.php
+++ b/lib/task/sfPropelBaseTask.class.php
@@ -370,6 +370,12 @@ abstract class sfPropelBaseTask extends sfBaseTask
         'dsn'      => $database->getParameter('dsn'),
         'user'     => $database->getParameter('username'),
         'password' => $database->getParameter('password'),
+        'settings'  => array(
+          'queries' => $database->getParameter('queries'),
+          'charset' => array(
+            'value' => $database->getParameter('encoding'),
+          ),
+        ),
       );
     }
     return $connections;
@@ -383,6 +389,12 @@ abstract class sfPropelBaseTask extends sfBaseTask
       'dsn'      => $database->getParameter('dsn'),
       'user'     => $database->getParameter('username'),
       'password' => $database->getParameter('password'),
+      'settings'  => array(
+        'queries' => $database->getParameter('queries'),
+        'charset' => array(
+          'value' => $database->getParameter('encoding'),
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
Before this PR more advanced migrations might fail or cause data issues when specific database configuration was used.
Mainly custom charset or collation.

Requires: https://github.com/propelorm/Propel/pull/697
