### PR TITLE
Fixes many-to-many joins in auto-generated filter forms

### DIFF
--- a/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterGeneratedTemplate.php
+++ b/data/generator/sfPropelFormFilter/default/template/sfPropelFormFilterGeneratedTemplate.php
@@ -56,7 +56,7 @@ abstract class Base<?php echo $this->table->getClassname() ?>FormFilter extends 
       return;
     }
 
-    $criteria->addJoin(<?php echo $middleTablePeerName ?>::<?php echo $columnPeerName ?>, <?php echo $this->table->getPeerClassname() ?>::<?php echo $pkPeerName ?>);
+    $criteria->addJoin(<?php echo $this->table->getPeerClassname() ?>::<?php echo $pkPeerName ?>, <?php echo $middleTablePeerName ?>::<?php echo $columnPeerName ?>);
 
     $value = array_pop($values);
     $criterion = $criteria->getNewCriterion(<?php echo $middleTablePeerName ?>::<?php echo $relatedColumnPeerName ?>, $value);


### PR DESCRIPTION
Solves the following exception for auto-generated filter forms with more than one many-to-many relation: SQLSTATE[42000]: Syntax error or access violation: 1066 Not unique table/alias: "tablename"

The original code generated joins from the foreign table to the target table which causes problems of duplicated alias names.
