### PR TITLE
Fixed issue causing persistent connection setting to not work

### DIFF
--- a/lib/database/sfPropelDatabase.class.php
+++ b/lib/database/sfPropelDatabase.class.php
@@ -109,10 +109,15 @@ class sfPropelDatabase extends sfPDODatabase
 
     if ($this->hasParameter('persistent'))
     {
+      $persistent = $this->getParameter('persistent');
+      if(!isset($persistent['value']))
+      {
+          $persistent = array('value' => $persistent);
+      }
       // for BC
       $this->setParameter('options', array_merge(
         $this->getParameter('options', array()),
-        array('ATTR_PERSISTENT' => $this->getParameter('persistent'))
+        array('ATTR_PERSISTENT' => $persistent)
       ));
     }
 


### PR DESCRIPTION
Sample databases.yml has setting:
persistent: true
So, $options is set to ATTR_PERSISTENT => true
However, in Propel.php  (propel/runtime/lib/Propel.php), the code reads:
private static function processDriverOptions($source, &$write_to)
{
foreach ($source as $option => $optiondata) {
...
...

$value = $optiondata['value'];
...
...
}
}
This sets the $value to null (as $optiondata is true, but
$optiondata['value'] evaluates to null).

So, for it to work, in databases.yml, persistence should be set as:
persistent: {value: true}

I assume this has been used in several installations already. So, I
fixed the code to accept both types of definitions:
persistent: {value: true}
and
persistent: true
