### PR TITLE
PHP 5.5 support

### DIFF
--- a/lib/form/sfFormFilterPropel.class.php
+++ b/lib/form/sfFormFilterPropel.class.php
@@ -327,6 +327,19 @@ abstract class sfFormFilterPropel extends sfFormFilter
 
   protected function camelize($text)
   {
-    return sfToolkit::pregtr($text, array('#/(.?)#e' => "'::'.strtoupper('\\1')", '/(^|_|-)+(.)/e' => "strtoupper('\\2')"));
+    $text = preg_replace_callback('#/(.?)#', array($this, 'camelizeFirstMatch'), $text);
+    $text = preg_replace_callback('/(^|_|-)+(.)/', array($this, 'camelizeSecondMatch'), $text);
+
+    return $text;
+  }
+
+  protected function camelizeFirstMatch($matches)
+  {
+    return '::'.strtoupper($matches[1]);
+  }
+
+  protected function camelizeSecondMatch($matches)
+  {
+    return strtoupper($matches[2]);
   }
 }


### PR DESCRIPTION
Fixed preg_replace calls with /e modifier.

Now plugin is fully compatible with PHP 5.5 when using this fork of Symfony 1.4: https://github.com/javer/symfony1.
