### PR TITLE
Fixed configuration for all:propel:param:persistent in database.yml and ...

### DIFF
--- a/config/skeleton/config/databases.yml
+++ b/config/skeleton/config/databases.yml
@@ -28,5 +28,5 @@ all:
       username:   root
       password:   
       encoding:   utf8
-      persistent: true
+      persistent: {value: true}
       pooling:    true

--- a/doc/database.md
+++ b/doc/database.md
@@ -18,7 +18,7 @@ Symfony is to specify slave servers for each connection in config/databases.yml 
           password:
 
           encoding:   utf8
-          persistent: true
+          persistent: {value: true}
           pooling:    true
 
           slaves:


### PR DESCRIPTION
...documentation for database.yml

Sample databases.yml has setting:

persistent: true
So, $options is set to ATTR_PERSISTENT => true
However, in Propel.php  (propel/runtime/lib/Propel.php), the code reads:
private static function processDriverOptions($source, &$write_to)
{
foreach ($source as $option => $optiondata) {
...
...

$value = $optiondata['value'];
...
...
}
}
This sets the $value to null (as $optiondata is true, but
$optiondata['value'] evaluates to null).

So, for it to work, in databases.yml, persistence should be set as:
persistent: {value: true}
