### PR TITLE
composer.json for newer versions of Propel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "http://www.propelorm.org/",
     "require": {
         "composer/installers": "*",
-        "propel/propel1": "1.6.*"
+        "propel/propel1": "~1.6"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This allows composer to install versions greater than 1.6.x of propel when using sfPropelORMPlugin
