### PR TITLE
sfPropelBaseTask->getConnections() must return only sfPropelDatabase connections params

### DIFF
--- a/lib/task/sfPropelBaseTask.class.php
+++ b/lib/task/sfPropelBaseTask.class.php
@@ -346,7 +346,7 @@ abstract class sfPropelBaseTask extends sfBaseTask
     return $ret;
   }
 
-  protected function getPhingPropertiesForConnection($databaseManager, $connection)
+  protected function getPhingPropertiesForConnection(sfDatabaseManager $databaseManager, $connection)
   {
     $database = $databaseManager->getDatabase($connection);
 
@@ -360,12 +360,18 @@ abstract class sfPropelBaseTask extends sfBaseTask
     );
   }
 
-  public function getConnections($databaseManager)
+  public function getConnections(sfDatabaseManager $databaseManager)
   {
     $connections = array();
     foreach ($databaseManager->getNames() as $connectionName)
     {
+      /** @var sfDatabase $database */
       $database = $databaseManager->getDatabase($connectionName);
+
+      if (!$database instanceof sfPropelDatabase) {
+        continue;
+      }
+
       $connections[$connectionName] = array(
         'adapter'  => $database->getParameter('phptype'),
         'dsn'      => $database->getParameter('dsn'),
@@ -382,7 +388,7 @@ abstract class sfPropelBaseTask extends sfBaseTask
     return $connections;
   }
 
-  public function getConnection($databaseManager, $connection)
+  public function getConnection(sfDatabaseManager $databaseManager, $connection)
   {
     $database = $databaseManager->getDatabase($connection);
     return array(
@@ -399,7 +405,7 @@ abstract class sfPropelBaseTask extends sfBaseTask
     );
   }
 
-  protected function getPlatform($databaseManager, $connection)
+  protected function getPlatform(sfDatabaseManager $databaseManager, $connection)
   {
     $params = $this->getConnection($databaseManager, $connection);
     $platformClass = ucfirst($params['adapter']) . 'Platform';
@@ -409,7 +415,7 @@ abstract class sfPropelBaseTask extends sfBaseTask
     return $platform;
   }
 
-  protected function getParser($databaseManager, $connection, $con)
+  protected function getParser(sfDatabaseManager $databaseManager, $connection, $con)
   {
     $params = $this->getConnection($databaseManager, $connection);
     $parserClass = ucfirst($params['adapter']) . 'SchemaParser';
@@ -483,7 +489,6 @@ abstract class sfPropelBaseTask extends sfBaseTask
       'nested_set' => 'nestedset.NestedSetBehavior',
       'sortable' => 'sortable.SortableBehavior',
       'sluggable' => 'sluggable.SluggableBehavior',
-      'sortable' => 'sortable.SortableBehavior',
       'concrete_inheritance' => 'concrete_inheritance.ConcreteInheritanceBehavior',
       'query_cache' => 'query_cache.QueryCacheBehavior',
       'aggregate_column' => 'aggregate_column.AggregateColumnBehavior',

--- a/test/bin/installer.php
+++ b/test/bin/installer.php
@@ -9,6 +9,9 @@ $this->logSection('install', 'default to propel');
 $this->logSection('install', 'default to sqlite');
 $this->runTask('configure:database', sprintf("'sqlite:%spropel.db'", sfConfig::get('sf_data_dir') . DIRECTORY_SEPARATOR));
 
+$this->logSection('install', 'secondary database');
+$this->runTask('configure:database', sprintf("--name=non-propel --class=sfPDODatabase 'sqlite:%spropel2.db'", sfConfig::get('sf_data_dir') . DIRECTORY_SEPARATOR));
+
 $this->logSection('install', 'fix sqlite database permissions');
 touch(sfConfig::get('sf_data_dir') . DIRECTORY_SEPARATOR .'propel.db');
 chmod(sfConfig::get('sf_data_dir'), 0777);

--- a/test/unit/task/sfPropelTaskTest.php
+++ b/test/unit/task/sfPropelTaskTest.php
@@ -1,0 +1,40 @@
+<?php
+
+$rootDir = dirname(__FILE__) . '/../../../../..';
+require_once dirname(__FILE__) . '/../../bootstrap/unit.php';
+
+$dispatcher = new sfEventDispatcher();
+require_once $rootDir.'/config/ProjectConfiguration.class.php';
+$configuration = new ProjectConfiguration($rootDir, $dispatcher);
+
+class sfPropelDummyTask extends sfPropelBaseTask
+{
+
+    public function checkProjectExists()
+    {
+    }
+
+    protected function execute($arguments = array(), $options = array())
+    {
+        $databaseManager = new sfDatabaseManager($this->configuration);
+        $connections = $this->getConnections($databaseManager);
+
+        $t = new lime_test(count($connections));
+        $t->diag('->getConnections()');
+
+        foreach ($connections as $name => $connection) {
+            $databaseInstance = $databaseManager->getDatabase($name);
+            $t->ok(
+                $databaseInstance instanceof sfPropelDatabase,
+                sprintf(
+                    '->getConnections() should return only sfPropelDatabase instance. "%s" returned',
+                    get_class($databaseInstance)
+                )
+            );
+        }
+    }
+
+}
+
+$task = new sfPropelDummyTask($dispatcher, new sfFormatter());
+$task->run();


### PR DESCRIPTION
When symfony project uses multiple databases (mongo), some Propel task (like diff) failed.
