### PR TITLE
Update sfFormPropel.class.php

### DIFF
--- a/lib/form/sfFormPropel.class.php
+++ b/lib/form/sfFormPropel.class.php
@@ -672,7 +672,7 @@ abstract class sfFormPropel extends sfFormObject
       $options['max_additions'] = $options['max_additions'] - $count;
     }
     $emptyForm = $this->getEmptyRelatedForm($relationName, $options);
-    $emptyForm->widgetSchema->setLabel($options['empty_name']);
+    $emptyForm->widgetSchema->setLabel($options['empty_label']);
     $relationForm->embedOptionalForm($emptyName, $emptyForm, $options['empty_decorator'], $options);
     $this->optionalForms[$prefix . $emptyName] = $emptyForm;
   }


### PR DESCRIPTION
set label was using empty_name not empty_label option and so empty_label option inneffective when using ->embedRelation
Edited line 675.
