### PR TITLE
Missing \ to escape a variable comment

### DIFF
--- a/lib/behavior/SfPropelBehaviorI18n.php
+++ b/lib/behavior/SfPropelBehaviorI18n.php
@@ -112,7 +112,7 @@ public function getCulture()
 /**
  * Sets the culture.
  *
- * @param string $culture The culture to set
+ * @param string \$culture The culture to set
  *
  * @return {$this->getTable()->getPhpName()}
  */


### PR DESCRIPTION
The variable is not displayed in documentation since the $ is not escaped and cause notice to be displayed if error level is high enough
