### PR TITLE
schema.custom.yml search pattern update

### DIFF
--- a/lib/task/sfPropelBaseTask.class.php
+++ b/lib/task/sfPropelBaseTask.class.php
@@ -119,13 +119,16 @@ abstract class sfPropelBaseTask extends sfBaseTask
         $schemaArray = $dbSchema->convertOldToNewYaml($schemaArray);
       }
 
-      $customSchemaFilename = str_replace(array(
-        str_replace(DIRECTORY_SEPARATOR, '/', sfConfig::get('sf_root_dir')).'/',
-        'plugins/',
-        'config/',
-        '/',
-        'schema.yml'
-      ), array('', '', '', '_', 'schema.custom.yml'), $schema);
+      list($pluginFolder, $schemaPath) = explode('/config/',$schema,2);
+      $pluginFolder = basename($pluginFolder);
+      $schemaPath = $pluginFolder . '/' . $schemaPath;
+
+      $customSchemaFilename = str_replace(
+          array('/', 'schema.yml'),
+          array('_', 'schema.custom.yml'),
+          $schemaPath
+      );
+      
       $customSchemas = sfFinder::type('file')->name($customSchemaFilename)->in($dirs);
 
       foreach ($customSchemas as $customSchema)


### PR DESCRIPTION
When a plugin is not directly in the plugins directory (using the sfProjectConfiguration::setPluginPath) the custom file might not be found.

Using this way of doing we always have a fix convention.

In my case the plugins are not under the project root so sf_root_dir is never found and so not replaced
