### PR TITLE
Fix for Reflection package discover 

### DIFF
--- a/lib/generator/sfPropelFormFilterGenerator.class.php
+++ b/lib/generator/sfPropelFormFilterGenerator.class.php
@@ -89,9 +89,18 @@ class sfPropelFormFilterGenerator extends sfPropelFormGenerator
       array_pop($packages);
       if (false === $pos = array_search($this->params['model_dir_name'], $packages))
       {
-        throw new InvalidArgumentException(
-          sprintf('Unable to find the model dir name (%s) in the package %s.', $this->params['model_dir_name'], implode('.', $packages))
-        );
+          $fileName = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . 
+            str_replace( '.', DIRECTORY_SEPARATOR, $table->getPackage()) . 
+              DIRECTORY_SEPARATOR . $table->getClassname() . '.class.php';
+          $packages  = explode(DIRECTORY_SEPARATOR, $fileName );
+          array_pop($packages);
+
+        if (false === $pos = array_search($this->params['model_dir_name'], $packages))
+        {
+          throw new InvalidArgumentException(
+            sprintf('Unable to find the model dir name (%s) in the package %s.', $this->params['model_dir_name'], implode('.', $packages))
+          );
+        }
       }
       $packages[$pos] = $this->params['filter_dir_name'];
       $baseDir = implode(DIRECTORY_SEPARATOR, $packages);

--- a/lib/generator/sfPropelFormGenerator.class.php
+++ b/lib/generator/sfPropelFormGenerator.class.php
@@ -93,9 +93,17 @@ class sfPropelFormGenerator extends sfGenerator
 
       if (false === $pos = array_search($this->params['model_dir_name'], $packages))
       {
-        throw new InvalidArgumentException(
-          sprintf('Unable to find the model dir name (%s) in the package %s.', $this->params['model_dir_name'], implode('.', $packages))
-        );
+        $fileName = sfConfig::get('sf_root_dir') . DIRECTORY_SEPARATOR . 
+          str_replace( '.', DIRECTORY_SEPARATOR, $table->getPackage()) . 
+            DIRECTORY_SEPARATOR . $table->getClassname() . '.class.php';
+        $packages  = explode(DIRECTORY_SEPARATOR, $fileName );
+        array_pop($packages);
+        if (false === $pos = array_search($this->params['model_dir_name'], $packages))
+        {
+          throw new InvalidArgumentException(
+            sprintf('Unable to find the model dir name (%s) in the package %s.', $this->params['model_dir_name'], implode('.', $packages))
+          );
+        }
       }
 
       $packages[$pos] = $this->params['form_dir_name'];


### PR DESCRIPTION
When you put modified class (i.e. sfGuardUser.class.php ) into /lib folder with the same name Reflection can't find original class and can't determine correct package file path and throw exception "Unable to find the model dir name (model) in the package"