### PR TITLE
Added missing PHP versions up to 7 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
     - 7.0
 
 env:
-    - SYMFONY_VERSION=symfony-1.4.17
     - SYMFONY_VERSION=symfony-1.4.20
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: php
 php:
     - 5.3
     - 5.4
+    - 5.5
+    - 5.6
+    - 7.0
 
 env:
     - SYMFONY_VERSION=symfony-1.4.17


### PR DESCRIPTION
sfPropelORMPlugin and Propel are compatible with PHP7 and if Travis says otherwise, we'll fix that