### PR TITLE
Build Propel database map per connection name. The lack of such separ…

### DIFF
--- a/lib/addon/sfPropelData.class.php
+++ b/lib/addon/sfPropelData.class.php
@@ -341,7 +341,7 @@ class sfPropelData extends sfData
 
     if(!$dbMap = $this->cache->get($cacheKey))
     {
-      $dbMap = Propel::getDatabaseMap();
+      $dbMap = Propel::getDatabaseMap($connectionName);
       $files = sfFinder::type('file')->name('*TableMap.php')->in(sfProjectConfiguration::getActive()->getModelDirs());
       foreach ($files as $file)
       {


### PR DESCRIPTION
…ation was the reason for incorrectly loading data from fixtures (eg. .yaml data file) for multiple connections.