### PR TITLE
Test with PHP > 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,14 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: precise
     - php: 5.5
     - php: 5.6
     - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
 
 env:
     - SYMFONY_BRANCH=propel SYMFONY_REPOSITORY=https://github.com/rozwell/symfony1.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - php: 5.4
       dist: precise
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
     - php: 7.1


### PR DESCRIPTION
CI is currently failing for PHP > 7.1 due to some deprecations triggered by https://github.com/rozwell/symfony1. 

I have prepared https://github.com/rozwell/symfony1/pull/1 which should fix them.